### PR TITLE
With static linking the plugin works on Alpine Linux as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: debug register test
 upgrade: register reload
 
 build:
-	GOOS=$(OS) GOARCH="$(GOARCH)" go build -o "$(OUTPUTFOLDER)/$(OUTPUTNAME)" $(GOBUILDFLAGS) -ldflags="-X 'github.com/vaups/benigma.Version=$(VERSION)' -X 'github.com/vaups/benigma.Commit=$(COMMIT)'" cmd/$(PROJECTNAME)/main.go
+	GOOS=$(OS) GOARCH="$(GOARCH)" CGO_ENABLED=0 go build -a -installsuffix cgo -o "$(OUTPUTFOLDER)/$(OUTPUTNAME)" $(GOBUILDFLAGS) -ldflags="-X 'github.com/vaups/benigma.Version=$(VERSION)' -X 'github.com/vaups/benigma.Commit=$(COMMIT)'" cmd/$(PROJECTNAME)/main.go
 	sha256sum $(OUTPUTFOLDER)/$(OUTPUTNAME)
 
 dev:


### PR DESCRIPTION
Fixed the issue #6 by adding flags `... CGO_ENABLED=0 go build -a -installsuffix cgo ...` on the build target of the Makefile.

Tested compiling with go1.20.1.linux-amd64 and running the plugin on hashicorp/vault:1.12.1 container.